### PR TITLE
app: don't use compileTime()

### DIFF
--- a/app.go
+++ b/app.go
@@ -73,7 +73,7 @@ func NewApp() *App {
 		Version:      "0.0.0",
 		BashComplete: DefaultAppComplete,
 		Action:       helpCommand.Action,
-		Compiled:     compileTime(),
+		Compiled:     time.Now(), // avoid compileTime() because of the Stat()
 		Writer:       os.Stdout,
 	}
 }


### PR DESCRIPTION
It causes an extra Stat() for the program name, and if you're within a
Keybase folder list this triggers a user-not-found error.

Issue: keybase/client#2237
