### PR TITLE
command: allow deeply-nested subcommands to have right full name

### DIFF
--- a/command.go
+++ b/command.go
@@ -202,7 +202,7 @@ func (c Command) startApp(ctx *Context) error {
 
 	var newCmds []Command
 	for _, cc := range app.Commands {
-		cc.commandNamePath = []string{c.Name, cc.Name}
+		cc.commandNamePath = []string{c.FullName(), cc.Name}
 		newCmds = append(newCmds, cc)
 	}
 	app.Commands = newCmds


### PR DESCRIPTION
Previously, a command like `keybase fs sync enable` would show `keybase sync enable` in the help text.

@songgao: this is to implement your comment in my client PR: https://github.com/keybase/client/pull/14666#discussion_r234389083