### PR TITLE
add Unlisted field to hide commands from lists

### DIFF
--- a/command.go
+++ b/command.go
@@ -16,6 +16,8 @@ type Command struct {
 	Aliases []string
 	// A short description of the usage of this command
 	Usage string
+	// Boolean to hide from command and subcommand lists.
+	Unlisted bool
 	// A longer explanation of how the command works
 	Description string
 	// Example usage

--- a/help.go
+++ b/help.go
@@ -24,8 +24,8 @@ AUTHOR(S):
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{end}}{{if .Flags}}
+   {{range .Commands}}{{if not .Unlisted}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{end}}{{end}}{{end}}{{if .Flags}}
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{end}}{{if .Copyright }}
@@ -64,8 +64,8 @@ USAGE:
    {{.Name}} command{{if .Flags}} [command options]{{end}} [arguments...]
 
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{if .Flags}}
+   {{range .Commands}}{{if not .Unlisted}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{end}}{{end}}{{if .Flags}}
 OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{end}}


### PR DESCRIPTION
Using empty `Usage`s to hide commands is suboptimal because it's subtle and people end up not writing helpful usages. Add a flag to hide commands so they can have both `Usage` and be unlisted. Some deja vu.

fyi this fork's tests don't compile